### PR TITLE
Fix SEO indexing issues: Remove signup.html from sitemap and 404.html…

### DIFF
--- a/404.html
+++ b/404.html
@@ -7,7 +7,6 @@
 
   <!-- SEO -->
   <meta name="robots" content="noindex" />
-  <link rel="canonical" href="https://trendfitapp.com/404.html">
   <meta property="og:url" content="https://trendfitapp.com/404.html">
 
 

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -34,12 +34,6 @@
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://trendfitapp.com/signup.html</loc>
-    <lastmod>2025-09-20</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
     <loc>https://trendfitapp.com/community.html</loc>
     <lastmod>2025-11-09</lastmod>
     <changefreq>monthly</changefreq>


### PR DESCRIPTION
… canonical tag

This commit addresses critical Google Search Console indexing issues:

1. Remove signup.html from sitemap.xml
   - signup.html redirects to community.html via meta refresh
   - Having it in sitemap created conflicting signals to Google
   - Removed entire entry to prevent indexing confusion

2. Remove canonical tag from 404.html
   - 404 error pages should not have canonical tags
   - Self-referencing canonical contradicted noindex directive
   - Keeping noindex meta tag (correct for 404 pages)

Impact:
- Eliminates "page with redirect" indexing issue
- Eliminates "improper canonical tag" indexing issue
- Eliminates "404 page canonical" confusion
- Improves Google Search Console health score
- Provides clearer signals to search engines

Related files:
- signup.html remains unchanged (still redirects to community.html)
- beta-feedback.html remains blocked (intentional, no changes needed)